### PR TITLE
testing with timeout and flating ip cleanup

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -43,7 +43,8 @@ labels:
 providers:
   - name: openstack2
     cloud: openstack2
-    clean-floating-ips: true
+    clean-floating-ips: false
+    port-cleanup-interval: 120
     image-name-format: "{image_name}-{timestamp}"
     boot-timeout: 120
     rate: 10.0


### PR DESCRIPTION
Why:
It seems nodepool is trying to reach the instance after the floating IP was removed from the instance. Therefore, we start seeing paramiko error (no valid host key) probably because it can no longer reach the systems.

I will try with the option to not clean the flaoting IP and try to reduce the timeout.